### PR TITLE
refactor: match on all commands in one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ cargo-nocode deploy
 Usage: cargo-nocode <command>
 
 Possible commands:
-- init    initialize a nocode applicaton
+- init    initialize a nocode application
 - build   build the nocode application
 - run     run the nocode application
 - deploy  deploy the nocode application

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,9 +32,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             File::create("nocode.rs")?;
             println!("Created nocode.rs! Now start by writing not any code.");
         }
-        "build" => {}
-        "run" => {}
-        "deploy" => {}
+        "build" | "run" | "deploy" => {}
         _ => usage(),
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ const USAGE_TEXT: &str = "
 Usage: cargo-nocode <command>
 
 Possible commands:
-- init    initialize a nocode applicaton
+- init    initialize a nocode application
 - build   build the nocode application
 - run     run the nocode application
 - deploy  deploy the nocode application


### PR DESCRIPTION
As the code for `build`, `run` and `deploy` is the same, we can match on all three at the same time, making it easier to read.

Also fixes two typos.